### PR TITLE
Region refactor

### DIFF
--- a/src/app/api/instances/[name]/delete/route.ts
+++ b/src/app/api/instances/[name]/delete/route.ts
@@ -1,28 +1,40 @@
 import { EC2Client } from "@aws-sdk/client-ec2";
 import { fetchInstance } from "@/utils/AWS/EC2/fetchInstace";
-import { NextResponse } from "next/server";
+import { NextRequest, NextResponse } from "next/server";
 import { deleteBroker } from "@/utils/AWS/EC2/deleteBrokerInstance";
 import { deleteFromDynamoDB } from "@/utils/dynamoDBUtils";
 
-const ec2Client = new EC2Client({ region: process.env.REGION });
-
 export async function POST(
-  request: Request,
-  { params }: { params: Promise<{ name: string }> }
+  request: NextRequest,
+  { params }: { params: Promise<{ name: string }> },
 ) {
   const { name } = await params;
+  const searchParams = request.nextUrl.searchParams;
+  const region = searchParams.get("region");
+
+  if (!region) {
+    return NextResponse.json(
+      { message: "Region parameter is missing" },
+      { status: 400 },
+    );
+  }
+
+  const ec2Client = new EC2Client({ region });
+
   const instance = await fetchInstance(name, ec2Client);
   const instanceId = instance?.InstanceId;
   if (instanceId === undefined) {
     return NextResponse.json(
       { message: `No instance found with name: ${name}` },
-      { status: 404 }
+      { status: 404 },
     );
   }
   await deleteBroker(instanceId, ec2Client);
-  await deleteFromDynamoDB("RabbitoryInstancesMetadata", { instanceId: { S: instanceId } });
+  await deleteFromDynamoDB("RabbitoryInstancesMetadata", {
+    instanceId: { S: instanceId },
+  });
   return NextResponse.json(
     { message: `Successfully deleted instance: ${name}` },
-    { status: 200 }
-  )
+    { status: 200 },
+  );
 }

--- a/src/app/api/instances/[name]/plugins/route.ts
+++ b/src/app/api/instances/[name]/plugins/route.ts
@@ -1,22 +1,31 @@
 import { EC2Client } from "@aws-sdk/client-ec2";
-import { NextResponse } from "next/server";
+import { NextRequest, NextResponse } from "next/server";
 import { fetchInstance } from "@/utils/AWS/EC2/fetchInstace";
 import { runSSMCommands } from "@/utils/AWS/SSM/runSSMCommands";
 import axios from "axios";
 
-const ec2Client = new EC2Client({ region: process.env.REGION });
-
 export async function GET(
-  request: Request,
-  { params }: { params: Promise<{ name: string }> }
+  request: NextRequest,
+  { params }: { params: Promise<{ name: string }> },
 ) {
+  const searchParams = request.nextUrl.searchParams;
+  const region = searchParams.get("region");
   const { name: instanceName } = await params;
+
+  if (!region) {
+    return NextResponse.json(
+      { message: "Missing region parameter" },
+      { status: 400 },
+    );
+  }
+
+  const ec2Client = new EC2Client({ region });
 
   const instance = await fetchInstance(instanceName, ec2Client);
   if (!instance) {
     return NextResponse.json(
       { message: `No instance found with name: ${instanceName}` },
-      { status: 404 }
+      { status: 404 },
     );
   }
   const publicDns = instance.PublicDnsName;
@@ -24,7 +33,7 @@ export async function GET(
   if (!publicDns) {
     return NextResponse.json(
       { message: "Instance not ready yet! Try again later!" },
-      { status: 404 }
+      { status: 404 },
     );
   }
 
@@ -44,16 +53,27 @@ export async function GET(
     console.error("Error fetching plugins:", error);
     return NextResponse.json(
       { message: "Error fetching plugins", error: String(error) },
-      { status: 500 }
+      { status: 500 },
     );
   }
 }
 
 export async function POST(
-  request: Request,
-  { params }: { params: Promise<{ name: string }> }
+  request: NextRequest,
+  { params }: { params: Promise<{ name: string }> },
 ) {
+  const searchParams = request.nextUrl.searchParams;
+  const region = searchParams.get("region");
   const { name: instanceName } = await params;
+
+  if (!region) {
+    return NextResponse.json(
+      { message: "Missing region parameter" },
+      { status: 400 },
+    );
+  }
+
+  const ec2Client = new EC2Client({ region });
 
   const { name, enabled } = (await request.json()) as {
     name: string;
@@ -64,7 +84,7 @@ export async function POST(
   if (!instance) {
     return NextResponse.json(
       { message: `No instance found with name: ${instanceName}` },
-      { status: 404 }
+      { status: 404 },
     );
   }
   const instanceId = instance.InstanceId;
@@ -87,7 +107,7 @@ export async function POST(
     console.error("Error updating plugins:", error);
     return NextResponse.json(
       { message: "Error updating plugins", error: String(error) },
-      { status: 500 }
+      { status: 500 },
     );
   }
 }

--- a/src/app/api/instances/[name]/versions/route.ts
+++ b/src/app/api/instances/[name]/versions/route.ts
@@ -1,15 +1,24 @@
 import { EC2Client } from "@aws-sdk/client-ec2";
-import { NextResponse } from "next/server";
+import { NextRequest, NextResponse } from "next/server";
 import { fetchInstance } from "@/utils/AWS/EC2/fetchInstace";
 import axios from "axios";
 
-const ec2Client = new EC2Client({ region: process.env.REGION });
-
 export async function GET(
-  request: Request,
+  request: NextRequest,
   { params }: { params: Promise<{ name: string }> },
 ) {
+  const searchParams = request.nextUrl.searchParams;
+  const region = searchParams.get("region");
   const { name: instanceName } = await params;
+
+  if (!region) {
+    return NextResponse.json(
+      { message: "Missing region parameter" },
+      { status: 400 },
+    );
+  }
+
+  const ec2Client = new EC2Client({ region });
 
   const instance = await fetchInstance(instanceName, ec2Client);
   if (!instance) {

--- a/src/app/api/instances/route.ts
+++ b/src/app/api/instances/route.ts
@@ -1,8 +1,18 @@
-import { EC2Client, DescribeInstancesCommand } from "@aws-sdk/client-ec2";
+import {
+  EC2Client,
+  DescribeInstancesCommand,
+  DescribeInstancesCommandOutput,
+  Instance,
+} from "@aws-sdk/client-ec2";
 import { NextResponse } from "next/server";
 import { pollRabbitMQServerStatus } from "@/utils/RabbitMQ/serverStatus";
 import createInstance from "@/utils/AWS/EC2/createBrokerInstance";
-const ec2Client = new EC2Client({ region: process.env.REGION });
+import { getEC2Regions } from "@/utils/AWS/EC2/getEC2Regions";
+
+// Define an interface that extends the AWS Instance with a non-optional region.
+export interface InstanceWithRegion extends Instance {
+  region: string;
+}
 
 export const GET = async () => {
   const params = {
@@ -18,31 +28,63 @@ export const GET = async () => {
     ],
   };
 
-  const command = new DescribeInstancesCommand(params);
-  const response = await ec2Client.send(command);
+  const regions = await getEC2Regions();
+  if (!regions || regions.length === 0) {
+    return new NextResponse("No regions found", { status: 404 });
+  }
 
-  if (!response.Reservations) {
+  const command = new DescribeInstancesCommand(params);
+
+  // Build promises that return a list of Region-annotated instances.
+  const instancePromises: Promise<InstanceWithRegion[]>[] = regions.map(
+    async (region) => {
+      const ec2Client = new EC2Client({ region });
+      try {
+        const response = (await ec2Client.send(
+          command,
+        )) as DescribeInstancesCommandOutput;
+
+        // Create a new array with the region attached for each instance.
+        const regionInstances: InstanceWithRegion[] =
+          response.Reservations?.flatMap(
+            (reservation) =>
+              reservation.Instances?.map((instance) => ({
+                ...instance,
+                region: region!, // Assert that region is defined.
+              })) ?? [],
+          ) ?? [];
+
+        return regionInstances;
+      } catch (error) {
+        console.error(`Error querying region ${region}:`, error);
+        return [];
+      }
+    },
+  );
+
+  // Flatten the array of arrays into a single array of instances.
+  const instances: InstanceWithRegion[] = (
+    await Promise.all(instancePromises)
+  ).flat();
+
+  if (instances.length === 0) {
     return new NextResponse("No instances found", { status: 404 });
   }
 
-  const instances = response.Reservations.flatMap(
-    (reservation) => reservation.Instances,
-  );
-
-  const formattedInstances = instances.map((instance) => {
-    if (!instance || !instance.Tags) {
-      console.error("Instance or tags not found");
-      return NextResponse.json(
-        { message: "Instance or tags not found" },
-        { status: 404 },
-      );
-    }
-
-    return {
-      name: instance.Tags.find((tag) => tag.Key === "Name")?.Value || "",
-      id: instance.InstanceId,
-    };
-  });
+  const formattedInstances = instances
+    .map((instance) => {
+      if (!instance || !instance.Tags) {
+        console.error("Instance or tags not found");
+        return null;
+      }
+      const name = instance.Tags.find((tag) => tag.Key === "Name")?.Value || "";
+      return {
+        name,
+        id: instance.InstanceId,
+        region: instance.region,
+      };
+    })
+    .filter(Boolean);
 
   return NextResponse.json(formattedInstances);
 };
@@ -64,6 +106,7 @@ export const POST = async (request: Request) => {
     password,
     storageSize,
   } = body;
+
   const createInstanceResult = await createInstance(
     region,
     instanceName,

--- a/src/app/instances/[name]/configuration/page.tsx
+++ b/src/app/instances/[name]/configuration/page.tsx
@@ -52,12 +52,9 @@ export default function ConfigurationPage() {
     setIsSaving(true);
     try {
       const response = await axios.post(
-        `/api/instances/${instance?.name}/configuration`,
+        `/api/instances/${instance?.name}/configuration?region=${instance?.region}`,
         {
-          configuration: {
-            ...configuration,
-            region: instance?.region,
-          },
+          configuration,
         },
       );
       //console.log(response.data);

--- a/src/app/instances/[name]/configuration/page.tsx
+++ b/src/app/instances/[name]/configuration/page.tsx
@@ -22,7 +22,7 @@ export default function ConfigurationPage() {
       setIsFetching(true);
       try {
         const response = await axios.get(
-          `/api/instances/${instance?.name}/configuration`,
+          `/api/instances/${instance?.name}/configuration?region=${instance?.region}`,
         );
         console.log(response.data);
         setConfiguration(response.data);
@@ -33,7 +33,7 @@ export default function ConfigurationPage() {
       }
     };
     fetchConfiguration();
-  }, [instance?.name]);
+  }, [instance?.name, instance?.region]);
 
   const handleChange = (
     e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement>,
@@ -54,7 +54,10 @@ export default function ConfigurationPage() {
       const response = await axios.post(
         `/api/instances/${instance?.name}/configuration`,
         {
-          configuration,
+          configuration: {
+            ...configuration,
+            region: instance?.region,
+          },
         },
       );
       //console.log(response.data);

--- a/src/app/instances/[name]/edit/delete/page.tsx
+++ b/src/app/instances/[name]/edit/delete/page.tsx
@@ -1,24 +1,14 @@
-"use client"
+"use client";
 
-import * as React from 'react';
-import {
-  useState,
-  useEffect,
-  ChangeEvent,
-  FormEvent
-} from 'react';
+import * as React from "react";
+import { useState, useEffect, ChangeEvent, FormEvent } from "react";
 import { useRouter } from "next/navigation";
-import axios from 'axios';
+import axios from "axios";
+import { useInstanceContext } from "../../InstanceContext";
 
-interface Params {
-  name: string;
-}
-interface DeletePageParams {
-  params: Promise<Params>;
-}
-
-export default function DeletePage({ params }: DeletePageParams) {
-  const { name } = React.use(params);
+export default function DeletePage() {
+  const { instance } = useInstanceContext();
+  const name = instance?.name;
   const [inputText, setInputText] = useState("");
   const [validInput, setValidInput] = useState(false);
   const router = useRouter();
@@ -26,37 +16,46 @@ export default function DeletePage({ params }: DeletePageParams) {
   useEffect(() => {
     const isValidInput = inputText === name;
     setValidInput(isValidInput);
-  }, [inputText, name])
+  }, [inputText, name]);
 
   const handleChange = (e: ChangeEvent<HTMLInputElement>) => {
     const value = e.target.value;
     setInputText(value);
     console.log(inputText);
-  }
+  };
 
   const handleDelete = async (e: FormEvent<HTMLFormElement>) => {
     e.preventDefault();
     try {
-      await axios.post(`/api/instances/${name}/delete`);
+      await axios.post(
+        `/api/instances/${name}/delete?region=${instance?.region}`,
+      );
       router.push(`/`);
     } catch (err) {
       console.error("Error deleting instance:", err);
     }
-  }
+  };
 
   return (
     <>
       <h1>{name} </h1>
-      <p><strong>By submitting the following form, this instance will be permanently deleted</strong></p >
-      <form action="" onSubmit={(e) => handleDelete(e)
-      }>
-        <label htmlFor='instance' > Type the instance name: </label>
-        < input type="text" name="instance" onChange={(e) => handleChange(e)} />
-        < button type="submit" disabled={!validInput}> Delete </button>
-        < button type="button" onClick={() => router.push(`/instances/${name}`)}>
+      <p>
+        <strong>
+          By submitting the following form, this instance will be permanently
+          deleted
+        </strong>
+      </p>
+      <form action="" onSubmit={(e) => handleDelete(e)}>
+        <label htmlFor="instance"> Type the instance name: </label>
+        <input type="text" name="instance" onChange={(e) => handleChange(e)} />
+        <button type="submit" disabled={!validInput}>
+          {" "}
+          Delete{" "}
+        </button>
+        <button type="button" onClick={() => router.push(`/instances/${name}`)}>
           Cancel
         </button>
-      </form >
+      </form>
     </>
-  )
+  );
 }

--- a/src/app/instances/[name]/plugins/page.tsx
+++ b/src/app/instances/[name]/plugins/page.tsx
@@ -16,7 +16,7 @@ export default function PluginsPage() {
       setIsFetching(true);
       try {
         const response = await axios.get(
-          `/api/instances/${instance?.name}/plugins`,
+          `/api/instances/${instance?.name}/plugins?region=${instance?.region}`,
         );
         console.log(response.data);
         setEnabledPlugins(response.data);
@@ -28,7 +28,7 @@ export default function PluginsPage() {
     };
 
     fetchPlugins();
-  }, [instance?.name]);
+  }, [instance?.name, instance?.region]);
 
   const handleSubmit = async (
     e: React.FormEvent<HTMLFormElement>,
@@ -46,10 +46,13 @@ export default function PluginsPage() {
     setIsSaving(true);
 
     try {
-      await axios.post(`/api/instances/${instance?.name}/plugins`, {
-        name: pluginName,
-        enabled: newValue,
-      });
+      await axios.post(
+        `/api/instances/${instance?.name}/plugins?region=${instance?.region}`,
+        {
+          name: pluginName,
+          enabled: newValue,
+        },
+      );
       console.log(`${pluginName} updated successfully to ${newValue}`);
     } catch (error) {
       console.error(`Error updating ${pluginName}:`, error);

--- a/src/app/instances/[name]/versions/page.tsx
+++ b/src/app/instances/[name]/versions/page.tsx
@@ -19,7 +19,7 @@ export default function VersionsPage() {
       setIsFetching(true);
       try {
         const response = await axios.get(
-          `/api/instances/${instance?.name}/versions`,
+          `/api/instances/${instance?.name}/versions?region=${instance?.region}`,
         );
         console.log(response.data);
         setVersions({
@@ -34,7 +34,7 @@ export default function VersionsPage() {
     };
 
     fetchVersions();
-  }, [instance?.name]);
+  }, [instance?.name, instance?.region]);
   return (
     <>
       {isFetching ? (

--- a/src/app/instances/page.tsx
+++ b/src/app/instances/page.tsx
@@ -9,6 +9,7 @@ import Dropdown from "../components/Dropdown";
 interface Instance {
   name: string;
   id: string;
+  region: string;
 }
 
 export default function Home() {
@@ -42,15 +43,22 @@ export default function Home() {
       ) : (
         <ul className="space-y-4">
           {instances.map((instance) => (
-            <li key={instance.name} className="flex justify-between items-center p-4 border rounded-lg shadow-sm bg-white hover:bg-gray-50">
-              <Link href={`/instances/${instance.name}`} className="text-xl text-blue-600 hover:underline">
-                {instance.name} | {instance.id}
+            <li
+              key={instance.name}
+              className="flex justify-between items-center p-4 border rounded-lg shadow-sm bg-white hover:bg-gray-50"
+            >
+              <Link
+                href={`/instances/${instance.name}`}
+                className="text-xl text-blue-600 hover:underline"
+              >
+                {instance.name} | {instance.id} | {instance.region}
               </Link>
               <Dropdown
                 label="edit"
-                options={
-                  { delete: () => router.push(`/instances/${instance.name}/edit/delete`) }
-                }
+                options={{
+                  delete: () =>
+                    router.push(`/instances/${instance.name}/edit/delete`),
+                }}
               />
             </li>
           ))}

--- a/src/utils/validateConfig.ts
+++ b/src/utils/validateConfig.ts
@@ -4,7 +4,7 @@ export interface ValidationResult {
 }
 
 export function validateConfiguration(
-  config: Record<string, string>
+  config: Record<string, string>,
 ): ValidationResult {
   const errors: Record<string, string> = {};
   if (config["log.exchange"] !== undefined) {


### PR DESCRIPTION
This refactors the front and backend to use / pass around the region for instances. The main page now shows all instances from all regions. Now there's no need for the `.env` in the backend for region querying.