### PR TITLE
Jqln/callie fixes

### DIFF
--- a/src/app/instances/[name]/alarms/components/NewAlarmModal.tsx
+++ b/src/app/instances/[name]/alarms/components/NewAlarmModal.tsx
@@ -52,18 +52,18 @@ export const NewAlarmModal = ({ onClose, onAddAlarms }: Props) => {
       return false;
     }
 
-    if (memoryThreshold && (memoryThreshold < 0 || memoryThreshold > 100)) {
+    if (memoryThreshold && (memoryThreshold < 1 || memoryThreshold > 100)) {
       setErrors((prev) => [
         ...prev,
-        "Memory threshold must be between 0 and 100.",
+        "Memory threshold must be between 1 and 100.",
       ]);
       return false;
     }
 
-    if (storageThreshold && (storageThreshold < 0 || storageThreshold > 100)) {
+    if (storageThreshold && (storageThreshold < 1 || storageThreshold > 100)) {
       setErrors((prev) => [
         ...prev,
-        "Storage threshold must be between 0 and 100.",
+        "Storage threshold must be between 1 and 100.",
       ]);
       return false;
     }

--- a/src/app/instances/[name]/configuration/components/ComponentsForm.tsx
+++ b/src/app/instances/[name]/configuration/components/ComponentsForm.tsx
@@ -9,7 +9,7 @@ interface Props {
   onChange: (e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement>) => void;
   onSubmit: (e: React.FormEvent<HTMLFormElement>) => void;
   disabled: boolean;
-  pending: boolean;
+  isPending: boolean;
 }
 
 export default function ComponentsForm({
@@ -18,6 +18,7 @@ export default function ComponentsForm({
   onChange,
   onSubmit,
   disabled,
+  isPending
 }: Props) {
   return (
     <form onSubmit={onSubmit}>
@@ -55,13 +56,13 @@ export default function ComponentsForm({
         <button
           type="submit"
           disabled={disabled}
-          className={`px-4 py-2 ${disabled
-            ? "bg-btnhover1 opacity-70 cursor-not-allowed"
-            : "bg-btn1 hover:bg-btnhover1 text-mainbg1 font-semibold rounded-sm flex items-center justify-center hover:shadow-[0_0_10px_#87d9da] transition-all duration-200"
-            }`
-          }
+          className={`px-4 py-2 ${
+            disabled
+              ? "bg-btnhover1 opacity-70 cursor-not-allowed"
+              : "bg-btn1 hover:bg-btnhover1 text-mainbg1 font-semibold rounded-sm flex items-center justify-center hover:shadow-[0_0_10px_#87d9da] transition-all duration-200"
+          }`}
         >
-          {disabled ? (
+          {isPending ? (
             <span className="flex items-center gap-2">
               <SubmissionSpinner />
               Saving ...

--- a/src/app/instances/[name]/configuration/components/ComponentsFormRow.tsx
+++ b/src/app/instances/[name]/configuration/components/ComponentsFormRow.tsx
@@ -29,7 +29,7 @@ export default function ComponentsFormRow({
           item.description
         )}
       </td>
-      <td className="p-2 border-b w-1/6 text-center">
+      <td className="p-2 border-b w-1/6 text-left">
         {isLoading ? (
           <div className="w-24 h-4 bg-gray-600 rounded-sm animate-pulse"></div>
         ) : item.type === "dropdown" && Array.isArray(item.options) ? (
@@ -45,6 +45,10 @@ export default function ComponentsFormRow({
               </option>
             ))}
           </select>
+        ) : Boolean(item.readOnly) ? (
+          <span className="text-sm w-full py-1 pl-2 ">
+            {configuration[item.key] ?? ""}
+          </span>
         ) : (
           <input
             type={item.type}

--- a/src/app/instances/[name]/configuration/page.tsx
+++ b/src/app/instances/[name]/configuration/page.tsx
@@ -114,8 +114,8 @@ export default function ConfigurationPage() {
         isLoading={isLoading}
         onChange={handleChange}
         onSubmit={handleSubmit}
-        disabled={errors.length > 0 || formPending()}
-        pending={formPending()}
+        disabled={formPending()}
+        isPending={formPending()}
       />
     </div>
   );

--- a/src/utils/validateConfig.ts
+++ b/src/utils/validateConfig.ts
@@ -35,9 +35,9 @@ export function validateConsumerTimeout(
   const num = Number(value);
   if (
     value !== undefined &&
-    (isNaN(num) || !Number.isInteger(num) || num < 0)
+    (isNaN(num) || !Number.isInteger(num) || num < 1)
   ) {
-    return "Consumer Timeout must be an integer greater than or equal to 0.";
+    return "Consumer Timeout must be an integer greater than or equal to 1.";
   }
   return null;
 }


### PR DESCRIPTION
Non-editable config options are now plain text instead of input fields.
Config option `consumer_timeout` must be >= 1.
All alarm thresholds must be >= 1.